### PR TITLE
php style array syntax in keys

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -13,7 +13,11 @@ function encode (obj, section) {
 
   Object.keys(obj).forEach(function (k, _, __) {
     var val = obj[k]
-    if (val && typeof val === "object") {
+    if( Object.prototype.toString.call(val) === "[object Array]" ){
+      for( var i = 0; i < val.length; i++){
+        out += safe(k) + "[] = " + safe(val[i]) + eol  
+      }    
+    }else if (val && typeof val === "object") {
       children.push(k)
     } else {
       out += safe(k) + " = " + safe(val) + eol
@@ -71,6 +75,21 @@ function decode (str) {
       case 'false':
       case 'null': value = JSON.parse(value)
     }
+
+    var newkey = key.replace('[]','');
+    if( key.indexOf('[]') !== -1 && newkey != '' ){
+        var oldvalue = p[newkey];
+        if( oldvalue == undefined ){
+          var newarray = [];
+          newarray.push(value);
+          value = newarray;
+        }else{
+          oldvalue.push(value);
+          value = oldvalue;
+        }
+        key = newkey;
+    }
+
     p[key] = value
   })
 

--- a/test/fixtures/foo.ini
+++ b/test/fixtures/foo.ini
@@ -30,3 +30,9 @@ a.b.c = abc
 
 ; this next one is not a comment!  it's escaped!
 nocomment = this\; this is not a comment
+
+;php style - see the parse_ini_file function
+[favcolors]
+fav[] = green
+fav[] = blue
+fav[] = yellow

--- a/test/foo.js
+++ b/test/foo.js
@@ -21,7 +21,11 @@ var i = require("../")
             + 'j = 2\n\n[x\\.y\\.z]\nx.y.z = xyz\n\n'
             + '[x\\.y\\.z.a\\.b\\.c]\n'
             + 'a.b.c = abc\n'
-            + 'nocomment = this\\; this is not a comment\n'
+            + 'nocomment = this\\; this is not a comment\n\n'
+            + '[favcolors]\n'
+            + 'fav[] = green\n'
+            + 'fav[] = blue\n'
+            + 'fav[] = yellow\n'
   , expectD =
     { o: 'p',
       'a with spaces': 'b  c',
@@ -39,6 +43,9 @@ var i = require("../")
           'a.b.c': 'abc',
           'nocomment': 'this\; this is not a comment'
         }
+      },
+      'favcolors' : {
+        'fav': ['green','blue','yellow']
       }
     }
 


### PR DESCRIPTION
PHP's parse_ini_file() allows ini files to have array-like syntax. Having square brackets in the key of an ini file causes unexpected results with ini.js as it stands today. I've updated it to allow for this syntax to function for both encoding and decoding an ini file.

example:
MyFavoriteColor[] = green
MyFavoriteColor[] = blue
MyFavoriteColor[] = yellow

The expected results would be an array with 3 values.

I've also added this to the tests in foo.js. This still passes all tests, and seems to work well.
