### PR TITLE
Update tap (~0.4.0) so that tests run again

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "tap": "~0.0.9"
+    "tap": "~0.4.0"
   }
 }


### PR DESCRIPTION
On a fresh clone, using node v0.10.28, you end would end up with a weird
error:

/tmp/node-ini/node_modules/tap/node_modules/tap-runner/runner.js:15
  Runner.super.call(this, diag)
               ^
TypeError: Cannot call method 'call' of undefined
