### PR TITLE
Add license to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
   "dependencies": {},
   "devDependencies": {
     "tap": "~0.4.0"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Add license so that tools such as [nlf](https://github.com/iandotkelly/nlf) can correctly identify license type.
