### PR TITLE
Supporting colons in .ini files for value binding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,15 @@ to the filesystem with the following content:
 
 ## API
 
-### decode(inistring)
+### decode(inistring, [options])
 
 Decode the ini-style formatted `inistring` into a nested object.
+
+The `options` object may contain the following:
+
+* `use_colons` If your ini-style formatted `inistring` also contains colons
+  instead of equal signs for value binding, set this value to `true`.
+  Defaults to `false`.
 
 ### parse(inistring)
 

--- a/ini.js
+++ b/ini.js
@@ -66,8 +66,9 @@ function dotSplit (str) {
         })
 }
 
-function decode (str) {
-  var out = {}
+function decode (str, options) {
+  var options = options || {}
+    , out = {}
     , p = out
     , section = null
     , state = "START"
@@ -75,6 +76,10 @@ function decode (str) {
     , re = /^\[([^\]]*)\]$|^([^=]+)(=(.*))?$/i
     , lines = str.split(/[\r\n]+/g)
     , section = null
+
+  if(options.use_colons) {
+    re = /^\[([^\]]*)\]$|^([^:|^=]+)([:|=](.*))?$/i;
+  }
 
   lines.forEach(function (line, _, __) {
     if (!line || line.match(/^\s*[;#]/)) return


### PR DESCRIPTION
If colons are used in the .ini file instead of equal signs for value binding, or even if both of them are used, then using the new option in the decode function is able to parse it.