### PR TITLE
Rollback commit b28e1b2 to fix broken tests

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -5,7 +5,7 @@ exports.stringify = exports.encode = encode
 exports.safe = safe
 exports.unsafe = unsafe
 
-var eol = process.platform === "win32" ? "\r\n" : "\n"
+var eol = "\n"
 
 function encode (obj, opt) {
   var children = []


### PR DESCRIPTION
Re: issue #13

I'm not sure the reason behind commit b28e1b2, but the tests pass for me on Windows 7 x64 after applying this patch.
