### PR TITLE
Trim any whitespace preceeding comment from value

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -176,6 +176,7 @@ function unsafe (val, doUnesc) {
         }
         esc = false
       } else if (';#'.indexOf(c) !== -1) {
+        unesc = unesc.trim()
         break
       } else if (c === '\\') {
         esc = true


### PR DESCRIPTION
Whitespace at the end of a line won't be included in any values thanks to the trim at the start of `unsafe()`, but any whitespace between the end of a value and the start of a comment does get included in returned values currently.
