### PR TITLE
Added an option for unsafe encoding according to Issue #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ The `options` object may contain the following:
   `=` character.  By default, whitespace is omitted, to be friendly to
   some persnickety old parsers that don't tolerate it well.  But some
   find that it's more human-readable and pretty with the whitespace.
+* `safe` Allows for unsafe encoding of values. If false, `I am a string=` 
+  would not result in `key="I am a string=" but in `key=I am a string=`. 
+  This might be useful when using other parsers that do not understand 
+  a quoted value
 
 For backwards compatibility reasons, if a `string` options is passed
 in, then it is assumed to be the `section` value.

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ The `options` object may contain the following:
   some persnickety old parsers that don't tolerate it well.  But some
   find that it's more human-readable and pretty with the whitespace.
 * `safe` Allows for unsafe encoding of values. If false, `I am a string=` 
-  would not result in `key="I am a string=" but in `key=I am a string=`. 
+  would not result in `key="I am a string="` but in `key=I am a string=`. 
   This might be useful when using other parsers that do not understand 
-  a quoted value
+  a quoted value.
 
 For backwards compatibility reasons, if a `string` options is passed
 in, then it is assumed to be the `section` value.

--- a/ini.js
+++ b/ini.js
@@ -19,7 +19,7 @@ function encode (obj, opt) {
   } else {
     opt = opt || {}
     opt.whitespace = opt.whitespace === true
-    opt.safe = opt.hasOwnProperty('safe') ? opt.safe : true; // Safe encoding is true by default
+    opt.safe = opt.hasOwnProperty('safe') ? opt.safe : true // Safe encoding is true by default
   }
 
   var separator = opt.whitespace ? ' = ' : '='

--- a/ini.js
+++ b/ini.js
@@ -13,11 +13,13 @@ function encode (obj, opt) {
   if (typeof opt === 'string') {
     opt = {
       section: opt,
-      whitespace: false
+      whitespace: false,
+      safe: true
     }
   } else {
     opt = opt || {}
     opt.whitespace = opt.whitespace === true
+    opt.safe = opt.hasOwnProperty('safe') ? opt.safe : true; // Safe encoding is true by default
   }
 
   var separator = opt.whitespace ? ' = ' : '='
@@ -31,7 +33,7 @@ function encode (obj, opt) {
     } else if (val && typeof val === 'object') {
       children.push(k)
     } else {
-      out += safe(k) + separator + safe(val) + eol
+      out += safe(k) + separator + (opt.safe ? safe(val) : val) + eol
     }
   })
 
@@ -44,7 +46,8 @@ function encode (obj, opt) {
     var section = (opt.section ? opt.section + '.' : '') + nk
     var child = encode(obj[k], {
       section: section,
-      whitespace: opt.whitespace
+      whitespace: opt.whitespace,
+      safe: opt.safe
     })
     if (out.length && child.length) {
       out += eol

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "name": "ini",
   "description": "An ini encoder/decoder for node",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "repository": {
     "type": "git",
     "url": "git://github.com/isaacs/ini.git"


### PR DESCRIPTION
Via the `safe` option, one can decide whether unsafe strings are to be quoted or not.

``` javascript
let section = { 'section': { 'key': 'I am a string=' } };

console.log(encode(section)); // key="I am a string="
console.log(encode(section, { 'safe': false })); // key=I am a string=
```
