### PR TITLE
Add support for empty sections

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -42,6 +42,9 @@ function encode (obj, opt) {
   children.forEach(function (k, _, __) {
     var nk = dotSplit(k).join('\\.')
     var section = (opt.section ? opt.section + '.' : '') + nk
+    if (typeof obj[k] == 'object' && Object.keys(obj[k]).length == 0) {
+      out += "[" + safe(k) + "]" + eol
+    }        
     var child = encode(obj[k], {
       section: section,
       whitespace: opt.whitespace

--- a/ini.js
+++ b/ini.js
@@ -42,9 +42,9 @@ function encode (obj, opt) {
   children.forEach(function (k, _, __) {
     var nk = dotSplit(k).join('\\.')
     var section = (opt.section ? opt.section + '.' : '') + nk
-    if (typeof obj[k] == 'object' && Object.keys(obj[k]).length == 0) {
-      out += "[" + safe(k) + "]" + eol
-    }        
+    if (typeof obj[k] === 'object' && Object.keys(obj[k]).length === 0) {
+      out += '[' + safe(k) + ']' + eol
+    }
     var child = encode(obj[k], {
       section: section,
       whitespace: opt.whitespace


### PR DESCRIPTION
the **ini.encode** function ignores keys with an empty object as value.
for example:

``` javascript
{
    "Foo": {
        "one": 1,
        "two": 2
    },
    "Bar" : {}
}
```

would result as an ini:
**[Foo]
one=1
two=2**

with this fix it would result as:
**[Foo]
one=1
two=2
[Bar]**

---

I had to make this change since in a project I'm working on, an empty section is essential.
