### PR TITLE
Add support for foo[bar] named values

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -88,7 +88,6 @@ function decode (str) {
       case 'false':
       case 'null': value = JSON.parse(value)
     }
-
     // Convert keys with '[]' suffix to an array
     if (key.length > 2 && key.slice(-2) === '[]') {
       key = key.substring(0, key.length - 2)
@@ -96,6 +95,17 @@ function decode (str) {
         p[key] = []
       } else if (!Array.isArray(p[key])) {
         p[key] = [p[key]]
+      }
+    } else {
+      // Convert keys with '[foo]' suffix to an object
+      var subKey = key.replace(new RegExp(/ *\[[^)]*\] */g), '')
+      var subValue = key.match(/\[(.*?)\]/)
+      if (subValue) {
+        subValue = subValue[1]
+        if (!p[subKey])
+          p[subKey] = {}
+        p[subKey][subValue] = value
+        return
       }
     }
 

--- a/ini.js
+++ b/ini.js
@@ -57,8 +57,8 @@ function encode (obj, opt) {
 
 function dotSplit (str) {
   return str.replace(/\1/g, '\u0002LITERAL\\1LITERAL\u0002')
-    .replace(/\\\./g, '\u0001')
-    .split(/\./).map(function (part) {
+  .replace(/\\\./g, '\u0001')
+  .split(/\./).map(function (part) {
     return part.replace(/\1/g, '\\.')
       .replace(/\2LITERAL\\1LITERAL\2/g, '\u0001')
   })
@@ -100,10 +100,11 @@ function decode (str) {
       // Convert keys with '[foo]' suffix to an object
       var subKey = key.replace(new RegExp(/ *\[[^)]*\] */g), '')
       var subValue = key.match(/\[(.*?)\]/)
-      if (subValue) {
+      if (subKey && subValue) {
         subValue = subValue[1]
-        if (!p[subKey])
+        if (!p[subKey]) {
           p[subKey] = {}
+        }
         p[subKey][subValue] = value
         return
       }
@@ -159,9 +160,9 @@ function safe (val) {
     val.match(/^\[/) ||
     (val.length > 1 &&
      isQuoted(val)) ||
-    val !== val.trim()) ?
-      JSON.stringify(val) :
-      val.replace(/;/g, '\\;').replace(/#/g, '\\#')
+     val !== val.trim())
+     ? JSON.stringify(val)
+     : val.replace(/;/g, '\\;').replace(/#/g, '\\#')
 }
 
 function unsafe (val, doUnesc) {


### PR DESCRIPTION
I have several *.ini configuration files that I use in different programming languages (mainly PHP, Node.js and Python) and I need to use foo[bar] named values.

eg. 
`
[env]
foo[bar] = foobar
`
This would improve cross language compatibility.
http://php.net/manual/en/function.parse-ini-file.php
