### PR TITLE
Some INI parsers demand EOL between section header and keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ The `options` object may contain the following:
   `=` character.  By default, whitespace is omitted, to be friendly to
   some persnickety old parsers that don't tolerate it well.  But some
   find that it's more human-readable and pretty with the whitespace.
+* `newline` Boolean to specify whether to put an additional newline
+  after a section header. Some INI file parsers (for example the TOSHIBA
+  FlashAir one) need this to parse the file successfully.  By default,
+  the additional newline is omitted.
 
 For backwards compatibility reasons, if a `string` options is passed
 in, then it is assumed to be the `section` value.

--- a/ini.js
+++ b/ini.js
@@ -13,11 +13,13 @@ function encode (obj, opt) {
   if (typeof opt === 'string') {
     opt = {
       section: opt,
-      whitespace: false
+      whitespace: false,
+      newline: false
     }
   } else {
     opt = opt || {}
     opt.whitespace = opt.whitespace === true
+    opt.newline = opt.newline === true
   }
 
   var separator = opt.whitespace ? ' = ' : '='
@@ -36,7 +38,7 @@ function encode (obj, opt) {
   })
 
   if (opt.section && out.length) {
-    out = '[' + safe(opt.section) + ']' + eol + out
+    out = '[' + safe(opt.section) + ']' + (opt.newline ? eol + eol : eol) + out
   }
 
   children.forEach(function (k, _, __) {
@@ -44,7 +46,8 @@ function encode (obj, opt) {
     var section = (opt.section ? opt.section + '.' : '') + nk
     var child = encode(obj[k], {
       section: section,
-      whitespace: opt.whitespace
+      whitespace: opt.whitespace,
+      newline: opt.newline
     })
     if (out.length && child.length) {
       out += eol

--- a/test/foo.js
+++ b/test/foo.js
@@ -71,6 +71,11 @@ var i = require("../")
             + '[log.level]\n'
             + 'label = debug\n'
             + 'value = 10\n'
+  , expectH = '[log]\n\n'
+            + 'type=file\n\n'
+            + '[log.level]\n\n'
+            + 'label=debug\n'
+            + 'value=10\n'
 
 test("decode from file", function (t) {
   var d = i.decode(data)
@@ -103,5 +108,13 @@ test("encode with whitespace", function (t) {
   e = i.encode(obj, {whitespace: true})
 
   t.equal(e, expectG)
+  t.end()
+})
+
+test("encode with newline", function (t) {
+  var obj = {log: { type:'file', level: {label:'debug', value:10} } }
+  e = i.encode(obj, {newline: true})
+
+  t.equal(e, expectH)
   t.end()
 })


### PR DESCRIPTION
This PR introduce new encoding option `newline` to add a second `eol` between the section header and the first key-value pair. It is needed at least one INI file parser used in the embedded world such as the Toshiba FlashAir `/SD_WLAN/CONFIG` file... to be able to boot (here I think you feel my pain).

**Note:** this PR includes an additional test in the existing test suite.
