### PR TITLE
New option `opt.platform` to force line-endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ The `options` object may contain the following:
   `=` character.  By default, whitespace is omitted, to be friendly to
   some persnickety old parsers that don't tolerate it well.  But some
   find that it's more human-readable and pretty with the whitespace.
+* `newline` Boolean to specify whether to put an additional newline
+  after a section header. Some INI file parsers (for example the TOSHIBA
+  FlashAir one) need this to parse the file successfully.  By default,
+  the additional newline is omitted.
 
 For backwards compatibility reasons, if a `string` options is passed
 in, then it is assumed to be the `section` value.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ The `options` object may contain the following:
   after a section header. Some INI file parsers (for example the TOSHIBA
   FlashAir one) need this to parse the file successfully.  By default,
   the additional newline is omitted.
+* `platform` String to define which platform this INI file is expected
+  to be used with: when `platform` is `win32`, line terminations are
+  CR+LF, for other platforms line termination is LF.  By default the
+  current platform name is used.
 
 For backwards compatibility reasons, if a `string` options is passed
 in, then it is assumed to be the `section` value.

--- a/ini.js
+++ b/ini.js
@@ -13,11 +13,13 @@ function encode (obj, opt) {
   if (typeof opt === 'string') {
     opt = {
       section: opt,
-      whitespace: false
+      whitespace: false,
+      newline: false
     }
   } else {
     opt = opt || {}
     opt.whitespace = opt.whitespace === true
+    opt.newline = opt.newline === true
   }
 
   var separator = opt.whitespace ? ' = ' : '='
@@ -36,7 +38,7 @@ function encode (obj, opt) {
   })
 
   if (opt.section && out.length) {
-    out = '[' + safe(opt.section) + ']' + eol + out
+    out = '[' + safe(opt.section) + ']' + (opt.newline ? eol + eol : eol) + out
   }
 
   children.forEach(function (k, _, __) {
@@ -44,7 +46,8 @@ function encode (obj, opt) {
     var section = (opt.section ? opt.section + '.' : '') + nk
     var child = encode(obj[k], {
       section: section,
-      whitespace: opt.whitespace
+      whitespace: opt.whitespace,
+      newline: opt.newline
     })
     if (out.length && child.length) {
       out += eol

--- a/ini.js
+++ b/ini.js
@@ -4,8 +4,6 @@ exports.stringify = exports.encode = encode
 exports.safe = safe
 exports.unsafe = unsafe
 
-var eol = process.platform === 'win32' ? '\r\n' : '\n'
-
 function encode (obj, opt) {
   var children = []
   var out = ''
@@ -14,14 +12,17 @@ function encode (obj, opt) {
     opt = {
       section: opt,
       whitespace: false,
-      newline: false
+      newline: false,
+      platform: process.platform
     }
   } else {
     opt = opt || {}
     opt.whitespace = opt.whitespace === true
     opt.newline = opt.newline === true
+    opt.platform = opt.platform || process.platform
   }
 
+  var eol = opt.platform === 'win32' ? '\r\n' : '\n'
   var separator = opt.whitespace ? ' = ' : '='
 
   Object.keys(obj).forEach(function (k, _, __) {
@@ -47,7 +48,8 @@ function encode (obj, opt) {
     var child = encode(obj[k], {
       section: section,
       whitespace: opt.whitespace,
-      newline: opt.newline
+      newline: opt.newline,
+      platform: opt.platform
     })
     if (out.length && child.length) {
       out += eol

--- a/test/foo.js
+++ b/test/foo.js
@@ -71,6 +71,11 @@ var i = require("../")
             + '[log.level]\n'
             + 'label = debug\n'
             + 'value = 10\n'
+  , expectH = '[log]\n\n'
+            + 'type=file\n\n'
+            + '[log.level]\n\n'
+            + 'label=debug\n'
+            + 'value=10\n'
 
 test("decode from file", function (t) {
   var d = i.decode(data)
@@ -103,5 +108,13 @@ test("encode with whitespace", function (t) {
   e = i.encode(obj, {whitespace: true})
 
   t.equal(e, expectG)
+  t.end()
+})
+
+test("encode with newline", function (t) {
+  var obj = {log: { type:'file', level: {label:'debug', value:10} } }
+  e = i.encode(obj, {newline: true})
+
+  t.equal(e, expectH)
   t.end()
 })

--- a/test/foo.js
+++ b/test/foo.js
@@ -76,6 +76,11 @@ var i = require("../")
             + '[log.level]\n\n'
             + 'label=debug\n'
             + 'value=10\n'
+  , expectI = '[log]\r\n'
+            + 'type=file\r\n\r\n'
+            + '[log.level]\r\n'
+            + 'label=debug\r\n'
+            + 'value=10\r\n'
 
 test("decode from file", function (t) {
   var d = i.decode(data)
@@ -116,5 +121,13 @@ test("encode with newline", function (t) {
   e = i.encode(obj, {newline: true})
 
   t.equal(e, expectH)
+  t.end()
+})
+
+test("encode with CR+LF", function (t) {
+  var obj = {log: { type:'file', level: {label:'debug', value:10} } }
+  e = i.encode(obj, {platform: 'win32'})
+
+  t.equal(e, expectI)
   t.end()
 })


### PR DESCRIPTION
This is useful when  generating a file which is not  intended to be used
on the same platform as the current one.  Most embedded system today use
the DOS/Windows format only.

**Notes:**
1. This PR includes an additional test in the existing test suite.
2. This PR depends on my previous one (which adds `opt.newline`) https://github.com/npm/ini/pull/63
