### PR TITLE
Added literalDot option to decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,20 @@ to the filesystem with the following content:
 
 ## API
 
-### decode(inistring)
+### decode(inistring, [options])
 
 Decode the ini-style formatted `inistring` into a nested object.
 
-### parse(inistring)
+`options`, when provided, must be an object with zero or more of the
+following keys:
 
-Alias for `decode(inistring)`
+* `literalDot` A boolean indicating whether a dot should be treated
+  as part of the property name, rather than as a section delimiter.
+  Defaults to `false`. If `true`, no nested sections will be created.
+
+### parse(inistring, [options])
+
+Alias for `decode(inistring, options)`
 
 ### encode(object, [options])
 

--- a/ini.js
+++ b/ini.js
@@ -64,7 +64,8 @@ function dotSplit (str) {
   })
 }
 
-function decode (str) {
+function decode (str, opt) {
+  opt = opt || {}
   var out = {}
   var p = out
   var section = null
@@ -108,32 +109,34 @@ function decode (str) {
     }
   })
 
-  // {a:{y:1},"a.b":{x:2}} --> {a:{y:1,b:{x:2}}}
-  // use a filter to return the keys that have to be deleted.
-  Object.keys(out).filter(function (k, _, __) {
-    if (!out[k] ||
-      typeof out[k] !== 'object' ||
-      Array.isArray(out[k])) {
-      return false
-    }
-    // see if the parent section is also an object.
-    // if so, add it to that, and mark this one for deletion
-    var parts = dotSplit(k)
-    var p = out
-    var l = parts.pop()
-    var nl = l.replace(/\\\./g, '.')
-    parts.forEach(function (part, _, __) {
-      if (!p[part] || typeof p[part] !== 'object') p[part] = {}
-      p = p[part]
+  if (!opt.literalDot) {
+    // {a:{y:1},"a.b":{x:2}} --> {a:{y:1,b:{x:2}}}
+    // use a filter to return the keys that have to be deleted.
+    Object.keys(out).filter(function (k, _, __) {
+      if (!out[k] ||
+        typeof out[k] !== 'object' ||
+        Array.isArray(out[k])) {
+        return false
+      }
+      // see if the parent section is also an object.
+      // if so, add it to that, and mark this one for deletion
+      var parts = dotSplit(k)
+      var p = out
+      var l = parts.pop()
+      var nl = l.replace(/\\\./g, '.')
+      parts.forEach(function (part, _, __) {
+        if (!p[part] || typeof p[part] !== 'object') p[part] = {}
+        p = p[part]
+      })
+      if (p === out && nl === l) {
+        return false
+      }
+      p[nl] = out[k]
+      return true
+    }).forEach(function (del, _, __) {
+      delete out[del]
     })
-    if (p === out && nl === l) {
-      return false
-    }
-    p[nl] = out[k]
-    return true
-  }).forEach(function (del, _, __) {
-    delete out[del]
-  })
+  }
 
   return out
 }

--- a/test/fixtures/literalDot.ini
+++ b/test/fixtures/literalDot.ini
@@ -1,0 +1,6 @@
+; These should not create subsections when used with literalDot: true option
+[http://example.com]
+foo=true
+
+[**/*.js]
+bar=true

--- a/test/literalDot.js
+++ b/test/literalDot.js
@@ -1,0 +1,21 @@
+var api = require("../")
+  , tap = require("tap")
+  , test = tap.test
+  , fs = require("fs")
+  , path = require("path")
+  , fixture = path.resolve(__dirname, "./fixtures/literalDot.ini")
+  , data = fs.readFileSync(fixture, "utf8")
+  , expected = {
+    "http://example.com": {
+       foo: true
+    },
+    "**/*.js": {
+       bar: true
+    }
+  }
+
+test("decode from file (literalDot: true)", function (t) {
+  var actual = api.decode(data, { literalDot: true })
+  t.deepEqual(actual, expected)
+  t.end()
+})


### PR DESCRIPTION
Refs #60. (Still might need a documentation update as well, though.)

This option allows dots to always be treated literally, without need for escapes. (My use case: I'm trying to implement an .editorconfig reader, which uses a similar format to INI but which uses glob patterns as section names. So there's no need for nesting on dot values.)

I'm not 100% sure about these changes because I get test failures on my local repo. I'm *thinking* it might be an LF vs CRLF problem rather than a real issue, but I'm not 100% sure. So if I missed any issues in the sections of code I've changed/added, I apologize in advance. I'm hoping Travis will help me catch anything I might have missed, as well.