### PR TITLE
Mocha Framework conflict

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -70,7 +70,12 @@ function decode (str) {
   var section = null
   //          section     |key      = value
   var re = /^\[([^\]]*)\]$|^([^=]+)(=(.*))?$/i
-  var lines = str.split(/[\r\n]+/g)
+  var lines = [];
+  str = str.toString();
+  
+  if(str.length > 0){
+	lines = str.split(/[\r\n]+/g);
+  }
 
   lines.forEach(function (line, _, __) {
     if (!line || line.match(/^\s*[;#]/)) return


### PR DESCRIPTION
Running Mocha along with ini module, a conflict occurs when the decode function is called. The conflict is about the input buffer which is not converted to a string explicitly. This fix is required in order to carry on with testing. It is a change in the initialization of the function's data, not in its logic.