### PR TITLE
Allow the module to be used in any CommonJS environment

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -4,7 +4,7 @@ exports.stringify = exports.encode = encode
 exports.safe = safe
 exports.unsafe = unsafe
 
-var eol = process.platform === 'win32' ? '\r\n' : '\n'
+var eol = typeof process !== 'undefined' && process.platform === 'win32' ? '\r\n' : '\n'
 
 function encode (obj, opt) {
   var children = []


### PR DESCRIPTION
I.e. browserify, by not accessing the global process variable unless it is defined.

(I wanted to use this in an example in Eloquent JavaScript's in-book coding environment. But it seems generally useful to have a solid ini parser that can be used in the browser.)