### PR TITLE
Trim line with whitespace character

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -75,6 +75,7 @@ function decode (str) {
   var lines = str.split(/[\r\n]+/g)
 
   lines.forEach(function (line, _, __) {
+    line = line.trim()
     if (!line || line.match(/^\s*[;#]/)) return
     var match = line.match(re)
     if (!match) return

--- a/test/fixtures/foo.ini
+++ b/test/fixtures/foo.ini
@@ -10,7 +10,7 @@ o = p
 
 ; Test single quotes
 s = 'something'
-
+    
 ; Test mixing quotes
 
 s1 = "something'


### PR DESCRIPTION
when we have line with only white-space character the decoded object would be `'':true`. So I saw `line.trim()` does the trick.