### PR TITLE
Adding failing test for semicolon in a list of strings

### DIFF
--- a/test/fixtures/foo.ini
+++ b/test/fixtures/foo.ini
@@ -24,6 +24,7 @@ ar[] = one
 ar[] = three
 ; This should be included in the array
 ar   = this is included
+ar2 = ['this is a string in an array', "this; is not a comment"]
 
 ; Test resetting of a value (and not turn it into an array)
 br = cold

--- a/test/foo.js
+++ b/test/foo.js
@@ -17,6 +17,8 @@ var i = require("../")
             + 'ar[]=one\n'
             + 'ar[]=three\n'
             + 'ar[]=this is included\n'
+            + "ar2[]='this is a string in an array'\n"
+            + "ar2[]='this; is not a comment'\n"
             + 'br=warm\n'
             + 'eq=\"eq=eq\"\n'
             + '\n'
@@ -43,6 +45,7 @@ var i = require("../")
       's2': 'something else',
       'zr': ['deedee'],
       'ar': ['one', 'three', 'this is included'],
+      'ar2': ['this is a string in an array', 'this; is not a comment'],
       'br': 'warm',
       'eq': 'eq=eq',
       a:


### PR DESCRIPTION
This PR adds a failing test for https://github.com/npm/ini/issues/81. Obviously, it should be fixed before this is merged.