### PR TITLE
Fix eol in ini.js

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -28,7 +28,7 @@ function encode (obj, opt) {
     var val = obj[k]
     if (val && Array.isArray(val)) {
       val.forEach(function (item) {
-        out += safe(k + '[]') + separator + safe(item) + '\n'
+        out += safe(k + '[]') + separator + safe(item) + eol
       })
     } else if (val && typeof val === 'object') {
       children.push(k)


### PR DESCRIPTION
There was only one spot, but it used `'\n'` instead of the `eol` variable that was decided at the top of the file.