### PR TITLE
addition option for unescaped character

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -15,11 +15,13 @@ function encode (obj, opt) {
   if (typeof opt === 'string') {
     opt = {
       section: opt,
-      whitespace: false
+      whitespace: false,
+      unescapedfields: opt.unescapedfields
     }
   } else {
     opt = opt || {}
     opt.whitespace = opt.whitespace === true
+    opt.unescapedfields = opt.unescapedfields || []
   }
 
   var separator = opt.whitespace ? ' = ' : '='
@@ -33,7 +35,13 @@ function encode (obj, opt) {
     } else if (val && typeof val === 'object') {
       children.push(k)
     } else {
-      out += safe(k) + separator + safe(val) + eol
+      if(Array.isArray(unescapedFields) && unescapedFields.includes(k)){
+        out += safe(k) + separator + safe(val)
+          .replace(/\\#/g, '#')
+          .replace(/\\\\/g, '\\') + eol
+      } else {
+        out += safe(k) + separator + safe(val) + eol
+      }
     }
   })
 

--- a/ini.js
+++ b/ini.js
@@ -25,6 +25,7 @@ function encode (obj, opt) {
   }
 
   var separator = opt.whitespace ? ' = ' : '='
+  var unescapedFields = opt.unescapedfields;
 
   Object.keys(obj).forEach(function (k, _, __) {
     var val = obj[k]


### PR DESCRIPTION
Using a set with an ODBC connector that identifies \ # as two characters, it is always the wrong password.
adds the option of not escaping objects.