### PR TITLE
Add option to set custom section delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,16 @@ to the filesystem with the following content:
 
 ## API
 
-### decode(inistring)
+### decode(inistring, [options])
 
 Decode the ini-style formatted `inistring` into a nested object.
 
-### parse(inistring)
+The `options` object may contain the following:
+
+* `delimiter` Character used when splitting sections into nested objects.
+  Can be set to `false` to disable splitting. Defaults to `"."`.
+
+### parse(inistring, [options])
 
 Alias for `decode(inistring)`
 
@@ -78,6 +83,8 @@ The `options` object may contain the following:
   `=` character.  By default, whitespace is omitted, to be friendly to
   some persnickety old parsers that don't tolerate it well.  But some
   find that it's more human-readable and pretty with the whitespace.
+* `delimiter` Character used when joining nested objects into sections.
+  Defaults to `"."`.
 
 For backwards compatibility reasons, if a `string` options is passed
 in, then it is assumed to be the `section` value.

--- a/test/delimiter.js
+++ b/test/delimiter.js
@@ -1,0 +1,134 @@
+var i = require('../')
+var tap = require('tap')
+var test = tap.test
+
+test('decode with default delimiter', function (t) {
+  var decoded = i.decode([
+    '[a.b]',
+    'foo = 1',
+    '[c\\.d]',
+    'foo = 2',
+    '[a_b]',
+    'foo = 3'
+  ].join('\n'))
+  t.deepEqual(decoded, {
+    a: {
+      b: {
+        foo: '1'
+      }
+    },
+    'c.d': {
+      foo: '2'
+    },
+    'a_b': {
+      foo: '3'
+    }
+  })
+  t.end()
+})
+
+test('decode with custom delimiter', function (t) {
+  var decoded = i.decode([
+    '[a_b]',
+    'foo = 1',
+    '[c\\_d]',
+    'foo = 2',
+    '[a.b]',
+    'foo = 3'
+  ].join('\n'), { delimiter: '_' })
+  t.deepEqual(decoded, {
+    a: {
+      b: {
+        foo: '1'
+      }
+    },
+    'c.d': {
+      foo: '2'
+    },
+    'a.b': {
+      foo: '3'
+    }
+  })
+  t.end()
+})
+
+test('decode with no delimiter', function (t) {
+  var decoded = i.decode([
+    '[a.b]',
+    'foo = 1',
+    '[c\\.d]',
+    'foo = 2'
+  ].join('\n'), { delimiter: false })
+  t.deepEqual(decoded, {
+    'a.b': {
+      foo: '1'
+    },
+    'c.d': {
+      foo: '2'
+    }
+  })
+  t.end()
+})
+
+test('encode with default delimiter', function (t) {
+  var obj = {
+    a: {
+      b: {
+        foo: 'bar'
+      }
+    },
+    'a.b': {
+      foo: 'bar'
+    }
+  }
+  var encoded = i.encode(obj)
+  t.equal(encoded, [
+    '[a.b]',
+    'foo=bar',
+    '',
+    '[a\\.b]',
+    'foo=bar',
+    ''
+  ].join('\n'))
+  t.end()
+})
+
+test('encode with custom delimiter', function (t) {
+  var obj = {
+    a: {
+      b: {
+        foo: 'bar'
+      }
+    },
+    'a_b': {
+      foo: 'bar'
+    }
+  }
+  var encoded = i.encode(obj, { delimiter: '_' })
+  t.equal(encoded, [
+    '[a_b]',
+    'foo=bar',
+    '',
+    '[a\\_b]',
+    'foo=bar',
+    ''
+  ].join('\n'))
+  t.end()
+})
+
+test('encode with no delimiter set should default to dot', function (t) {
+  var obj = {
+    a: {
+      b: {
+        foo: 'bar'
+      }
+    }
+  }
+  var encoded = i.encode(obj, { delimiter: false })
+  t.equal(encoded, [
+    '[a.b]',
+    'foo=bar',
+    ''
+  ].join('\n'))
+  t.end()
+})


### PR DESCRIPTION


# What / Why

Adds an option to set or disable delimiter used when splitting sections into nested objets.

While splitting sections can be useful in some cases it also prevents others such as sections with URLs or paths:

```
[http://example.net]
...

[myfile.txt]
...
```

While it is possible to escape the dots using `myfile\.txt` for this parser it may break other libraries, e.g. when the ini-file is used written/read by some other tool. In my case I receive the ini-file from an integration and have no control over it.

It PR allows setting a custom delimiter or to disable splitting entirely (for reading, writing still requires a delimiter).

## References

* Fixes #60