### PR TITLE
Fixes str.split and numbers as strings

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -72,7 +72,7 @@ function decode (str) {
   var section = null
   //          section     |key      = value
   var re = /^\[([^\]]*)\]$|^([^=]+)(=(.*))?$/i
-  var lines = str.split(/[\r\n]+/g)
+  var lines = str.toString().split(/[\r\n]+/g)
 
   lines.forEach(function (line, _, __) {
     if (!line || line.match(/^\s*[;#]/)) return
@@ -85,6 +85,7 @@ function decode (str) {
     }
     var key = unsafe(match[2])
     var value = match[3] ? unsafe(match[4]) : true
+    if(!isNaN(value)) value = parseFloat(value);
     switch (value) {
       case 'true':
       case 'false':


### PR DESCRIPTION
<!-- What / Why -->
- Fixed "str.split is not a function" on some systems (line: 75)
- Outputs numbers as numbers and not strings (line: 88)
<!-- Describe the request in detail. What it does and why it's being changed. -->
On two of my systems "str.split" comes up as an invalid function. Re-converting it to string fixes this issue.
Added a line that converts numbers in the output from a string to a float to allow int's and floats.
