### PR TITLE
Support duplicate property names as array

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The `options` object may contain the following:
   `=` character.  By default, whitespace is omitted, to be friendly to
   some persnickety old parsers that don't tolerate it well.  But some
   find that it's more human-readable and pretty with the whitespace.
+* `withoutArraySuffix` Boolean to specify whether to insert `[]` as array properties. default is `false`.
 
 For backwards compatibility reasons, if a `string` options is passed
 in, then it is assumed to be the `section` value.

--- a/ini.js
+++ b/ini.js
@@ -78,7 +78,7 @@ function decode (str) {
   var bucket = {
     'root': {}
   }
-  var curSection = 'root';
+  var curSection = 'root'
 
   lines.forEach(function (line, _, __) {
     if (!line || line.match(/^\s*[;#]/)) return
@@ -88,14 +88,14 @@ function decode (str) {
       section = unsafe(match[1])
       p = out[section] = out[section] || {}
       bucket[section] = bucket[section] || {}
-      curSection = section;
+      curSection = section
       return
     }
     var key = unsafe(match[2])
     var value = match[3] ? unsafe(match[4]) : true
 
     var _keyWithoutArraySuffix = key.split('[]')[0]
-    var curBucket =  bucket[curSection];
+    var curBucket = bucket[curSection]
     curBucket[_keyWithoutArraySuffix] = curBucket[_keyWithoutArraySuffix] ? ++curBucket[_keyWithoutArraySuffix] : 1
 
     if (curBucket[_keyWithoutArraySuffix] > 1) key = _keyWithoutArraySuffix + '[]'

--- a/ini.js
+++ b/ini.js
@@ -75,7 +75,10 @@ function decode (str) {
   var re = /^\[([^\]]*)\]$|^([^=]+)(=(.*))?$/i
   var lines = str.split(/[\r\n]+/g)
   // for duplicate property statist
-  var bucket = {}
+  var bucket = {
+    'root': {}
+  }
+  var curSection = 'root';
 
   lines.forEach(function (line, _, __) {
     if (!line || line.match(/^\s*[;#]/)) return
@@ -84,15 +87,18 @@ function decode (str) {
     if (match[1] !== undefined) {
       section = unsafe(match[1])
       p = out[section] = out[section] || {}
+      bucket[section] = bucket[section] || {}
+      curSection = section;
       return
     }
     var key = unsafe(match[2])
     var value = match[3] ? unsafe(match[4]) : true
 
     var _keyWithoutArraySuffix = key.split('[]')[0]
-    bucket[_keyWithoutArraySuffix] = bucket[_keyWithoutArraySuffix] ? ++bucket[_keyWithoutArraySuffix] : 1
+    var curBucket =  bucket[curSection];
+    curBucket[_keyWithoutArraySuffix] = curBucket[_keyWithoutArraySuffix] ? ++curBucket[_keyWithoutArraySuffix] : 1
 
-    if (bucket[_keyWithoutArraySuffix] > 1) key = _keyWithoutArraySuffix + '[]'
+    if (curBucket[_keyWithoutArraySuffix] > 1) key = _keyWithoutArraySuffix + '[]'
 
     switch (value) {
       case 'true':

--- a/test/duplicate-properties.js
+++ b/test/duplicate-properties.js
@@ -1,63 +1,59 @@
 /*
  * @Author: John Trump
- * @Date: 2020-11-28 00:27:19
+ * @Date: 2020-11-28 15:26:01
  * @LastEditors: John Trump
- * @LastEditTime: 2020-11-28 01:20:46
+ * @LastEditTime: 2020-11-28 15:52:26
  */
 var ini = require("../ini");
-var result = ini.decode(`
-zr[] = deedee
-zr=123
-ar[] = one
-ar[] = three
-str = 3;
-brr = 1;
-brr = 2;
-brr = 3;
-brr = 3;
-`);
+var tap = require("tap");
+var test = tap.test;
 
-console.log('result: ', result);
-/*
-{
-  zr: [ 'deedee', '123' ],
-  ar: [ 'one', 'three' ],
-  arr: '3',
-  brr: [ '1', '2', '3', '3' ]
-}
- */
+test("decode with duplicate properties", function(t) {
+  var d = ini.decode(`
+  zr[] = deedee;
+  zr=123;
+  ar[] = one
+  ar[] = three;
+  str = 3;
+  brr = 1;
+  brr = 2;
+  brr = 3;
+  brr = 3;`);
+  t.deepEqual(d, {
+    zr: ["deedee", "123"],
+    ar: ["one", "three"],
+    str: "3",
+    brr: ["1", "2", "3", "3"],
+  });
+  t.end();
+});
 
-var obj = {
-  zr: ["deedee", "123"],
-  ar: ["one", "three"],
-  str: "3",
-  brr: ["1", "2", "3", "3"],
-};
+test("encode with duplicate properties", function(t) {
+  var d = ini.encode({
+    ar: ["1", "2", "3"],
+    br: ["1", "2"],
+  });
+  var excepted = 'ar[]=1\n'
+               + 'ar[]=2\n'
+               + 'ar[]=3\n'
+               + 'br[]=1\n'
+               + 'br[]=2\n'
+  t.deepEqual(d, excepted)
+  t.end();
+});
 
-var str = ini.encode(obj);
-console.log('str: ', str);
-/*
-zr[]=deedee
-zr[]=123
-ar[]=one
-ar[]=three
-arr=3
-brr[]=1
-brr[]=2
-brr[]=3
-brr[]=3
- */
-
-var strWithoutSuffix = ini.encode(obj, {withoutArraySuffix: true});
-/*
-strWithoutSuffix
-zr=deedee
-zr=123
-ar=one
-ar=three
-str=3
-brr=1
-brr=2
-brr=3
-brr=3 */
-console.log('strWithoutSuffix', strWithoutSuffix);
+test("encode with option with duplicate properties", function(t) {
+  var d = ini.encode({
+    ar: ["1", "2", "3"],
+    br: ["1", "2"],
+  }, {
+    withoutArraySuffix: true
+  });
+  var excepted = 'ar=1\n'
+               + 'ar=2\n'
+               + 'ar=3\n'
+               + 'br=1\n'
+               + 'br=2\n'
+  t.deepEqual(d, excepted)
+  t.end();
+});

--- a/test/duplicate-properties.js
+++ b/test/duplicate-properties.js
@@ -1,0 +1,63 @@
+/*
+ * @Author: John Trump
+ * @Date: 2020-11-28 00:27:19
+ * @LastEditors: John Trump
+ * @LastEditTime: 2020-11-28 01:20:46
+ */
+var ini = require("../ini");
+var result = ini.decode(`
+zr[] = deedee
+zr=123
+ar[] = one
+ar[] = three
+str = 3;
+brr = 1;
+brr = 2;
+brr = 3;
+brr = 3;
+`);
+
+console.log('result: ', result);
+/*
+{
+  zr: [ 'deedee', '123' ],
+  ar: [ 'one', 'three' ],
+  arr: '3',
+  brr: [ '1', '2', '3', '3' ]
+}
+ */
+
+var obj = {
+  zr: ["deedee", "123"],
+  ar: ["one", "three"],
+  str: "3",
+  brr: ["1", "2", "3", "3"],
+};
+
+var str = ini.encode(obj);
+console.log('str: ', str);
+/*
+zr[]=deedee
+zr[]=123
+ar[]=one
+ar[]=three
+arr=3
+brr[]=1
+brr[]=2
+brr[]=3
+brr[]=3
+ */
+
+var strWithoutSuffix = ini.encode(obj, {withoutArraySuffix: true});
+/*
+strWithoutSuffix
+zr=deedee
+zr=123
+ar=one
+ar=three
+str=3
+brr=1
+brr=2
+brr=3
+brr=3 */
+console.log('strWithoutSuffix', strWithoutSuffix);

--- a/test/fixtures/foo.ini
+++ b/test/fixtures/foo.ini
@@ -25,7 +25,7 @@ ar[] = three
 ; This should be included in the array
 ar   = this is included
 
-; Test resetting of a value (and not turn it into an array)
+; Test resetting of a value (turn it into an array)
 br = cold
 br = warm
 

--- a/test/fixtures/foo.ini
+++ b/test/fixtures/foo.ini
@@ -63,3 +63,10 @@ nocomment = this\; this is not a comment
 
 # this next one is not a comment!  it's escaped!
 noHashComment = this\# this is not a comment
+
+[duplicate]
+ar = 1
+ar = 2
+ar[] = 3
+br = 1;
+br = 2;

--- a/test/foo.js
+++ b/test/foo.js
@@ -34,6 +34,13 @@ var i = require("../")
             + '[x\\.y\\.z.a\\.b\\.c]\na.b.c=abc\n'
             + 'nocomment=this\\; this is not a comment\n'
             + 'noHashComment=this\\# this is not a comment\n'
+            + '\n'
+            + '[duplicate]\n'
+            + 'ar[]=1\n'
+            + 'ar[]=2\n'
+            + 'ar[]=3\n'
+            + 'br[]=1\n'
+            + 'br[]=2\n'
   , expectD =
     { o: 'p',
       'a with spaces': 'b  c',
@@ -60,6 +67,10 @@ var i = require("../")
           'nocomment': 'this\; this is not a comment',
           noHashComment: 'this\# this is not a comment'
         }
+      },
+      duplicate: {
+        ar: ["1", "2", "3"],
+        br: ["1", "2"]
       }
     }
   , expectF = '[prefix.log]\n'

--- a/test/foo.js
+++ b/test/foo.js
@@ -17,7 +17,8 @@ var i = require("../")
             + 'ar[]=one\n'
             + 'ar[]=three\n'
             + 'ar[]=this is included\n'
-            + 'br=warm\n'
+            + 'br[]=cold\n'
+            + 'br[]=warm\n'
             + 'eq=\"eq=eq\"\n'
             + '\n'
             + '[a]\n'
@@ -43,7 +44,7 @@ var i = require("../")
       's2': 'something else',
       'zr': ['deedee'],
       'ar': ['one', 'three', 'this is included'],
-      'br': 'warm',
+      'br': ['cold', 'warm'],
       'eq': 'eq=eq',
       a:
        { av: 'a val',


### PR DESCRIPTION
<!-- What / Why -->
Most implementations only support having one property with a given name in a section. But some programs use duplicate property names to implement multi-valued properties.

If the `ini` library can compatible this feature,  it will improve compatible with difference scenes. It all depends on the developer needs.

<!-- Describe the request in detail. What it does and why it's being changed. -->

This PR include these change about:

- handle duplicate property as array
- add new `options.withoutArraySuffix:boolean` for `encode` method to  decide output array include `[]` suffix or not
  default is `false` and will work just like before
- add test/duplicate-properties.js for 100% coverage test

## References
Wikipedia about INI file description in varying features: 
[Wikipedia  - INI file](https://en.wikipedia.org/wiki/INI_file#Duplicate_names)

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
