### PR TITLE
Change git repo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "2.0.0",
   "repository": {
     "type": "git",
-    "url": "git://github.com/isaacs/ini.git"
+    "url": "git://github.com/npm/ini.git"
   },
   "main": "ini.js",
   "scripts": {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

In the `package.json` the git repo url is specified as `isaacs/ini`, but that redirects you to `npm/ini` so it may just be more useful to say `npm/ini`.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

None