### PR TITLE
fix: residual space after section causes bad parsing

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -62,8 +62,8 @@ const decode = str => {
   const out = Object.create(null)
   let p = out
   let section = null
-  //          section     |key      = value
-  const re = /^\[([^\]]*)\]$|^([^=]+)(=(.*))?$/i
+  //          section         |key      = value
+  const re = /^\[([^\]]*)\].*$|^([^=]+)(=(.*))?$/i
   const lines = str.split(/[\r\n]+/g)
 
   for (const line of lines) {

--- a/test/fixtures/foo.ini
+++ b/test/fixtures/foo.ini
@@ -42,6 +42,9 @@ j = "{ o: "p", a: { av: "a val", b: { c: { e: "this [value]" } } } }"
 cr[] = four
 cr[] = eight
 
+; b section with a space after its title
+[b] 
+
 ; nested child without middle parent
 ; should create otherwise-empty a.b
 [a.b.c]

--- a/test/foo.js
+++ b/test/foo.js
@@ -51,6 +51,7 @@ var expectD =
          '[]': 'a square?',
          cr: ['four', 'eight'],
          b: { c: { e: '1', j: '2' } } },
+      b: {},
       'x.y.z': {
         'x.y.z': 'xyz',
         'a.b.c': {


### PR DESCRIPTION
Any character left on a line after a section should be ignored.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
If we try to parse this input :
```ini
; there is a space character left at the end of the next line
[section] 
key=value
```
I get the following result:
```js
{
  "[section]": true
  key: "value"
}
```
Instead, I want the section to be correctly parsed.
