### PR TITLE
fix for comma-separated lists

### DIFF
--- a/ini.js
+++ b/ini.js
@@ -107,7 +107,7 @@ const decode = str => {
     if (Array.isArray(p[key]))
       p[key].push(value)
     else
-      p[key] = value
+      p[key] = (p[key]) ? `${p[key]},${value}` : value
   }
 
   // {a:{y:1},"a.b":{x:2}} --> {a:{y:1,b:{x:2}}}


### PR DESCRIPTION
I'm using this module to parse Raspberry Pi /boot/config.txt, so adds fail-safe for key/value pairs formatted like this:

```
dtoverlay=gpio-ir,gpio_pin=17
```
