### PR TITLE
fix: use eol in ini.js

### DIFF
--- a/lib/ini.js
+++ b/lib/ini.js
@@ -24,7 +24,7 @@ const encode = (obj, opt) => {
     const val = obj[k]
     if (val && Array.isArray(val)) {
       for (const item of val)
-        out += safe(k + '[]') + separator + safe(item) + '\n'
+        out += safe(k + '[]') + separator + safe(item) + eol
     } else if (val && typeof val === 'object')
       children.push(k)
     else


### PR DESCRIPTION
There was only one spot, but it used '\n' instead of the eol variable

This is a rebase of https://github.com/npm/ini/pull/90
