### PR TITLE
chore: Updated tests

### DIFF
--- a/tap-snapshots/test/foo.js.test.cjs
+++ b/tap-snapshots/test/foo.js.test.cjs
@@ -37,10 +37,19 @@ Null Object {
   ],
   "br": "warm",
   "eq": "eq=eq",
+  "false": false,
+  "null": null,
   "o": "p",
   "s": "something",
   "s1": "\\"something'",
   "s2": "something else",
+  "s3": "",
+  "s4": "",
+  "s5": "   ",
+  "s6": " a ",
+  "s7": true,
+  "true": true,
+  "undefined": "undefined",
   "x.y.z": Null Object {
     "a.b.c": Null Object {
       "a.b.c": "abc",
@@ -63,6 +72,15 @@ a with spaces=b  c
 s=something
 s1="something'
 s2=something else
+s3=
+s4=
+s5="   "
+s6=" a "
+s7=true
+true=true
+false=false
+null=null
+undefined=undefined
 zr[]=deedee
 ar[]=one
 ar[]=three

--- a/test/fixtures/foo.ini
+++ b/test/fixtures/foo.ini
@@ -18,6 +18,33 @@ s1 = "something'
 ; Test double quotes
 s2 = "something else"
 
+; Test blank value
+s3 =
+
+; Test value with only spaces
+s4 =        
+
+; Test quoted value with only spaces
+s5 = '   '
+
+; Test quoted value with leading and trailing spaces
+s6 = ' a '
+
+; Test no equal sign
+s7
+
+; Test bool(true)
+true = true
+
+; Test bool(false)
+false = false
+
+; Test null
+null = null
+
+; Test undefined
+undefined = undefined
+
 ; Test arrays
 zr[] = deedee
 ar[] = one


### PR DESCRIPTION
Rebase of https://github.com/npm/ini/pull/26

Updated to clarify current encoded & decoded values

The following tests have been added to show value conversion:

 - keys without a defined value
 - values consisting of just spaces to illustrate trimming
 - values consisting of quoted spaces to illustrate no trimming
 - a key without an equal sign, gets set to true as a bool
 - 'true', 'false', and 'null' get parsed as JSON
 - 'undefined' is not parsed as JSON

The following INI file ....

```ini
; Test blank value
s3 =

; Test value with only spaces
s4 =

; Test quoted value with only spaces
s5 = '   '

; Test quoted value with leading and trailing spaces
s6 = ' a '

; Test no equal sign
s7

; Test bool(true)
true = true

; Test bool(false)
false = false

; Test null
null = null

; Test undefined
undefined = undefined
```

Results in the following object:

{
  s3: '',
  s4: '',
  s5: '   ',
  s6: ' a ',
  s7: true,
  true: true,
  false: false,
  null: null,
  undefined: 'undefined'
}

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
