### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/ini.js
+++ b/lib/ini.js
@@ -164,7 +164,7 @@ const unsafe = (val, doUnesc) => {
   if (isQuoted(val)) {
     // remove the single quotes before calling JSON.parse
     if (val.charAt(0) === "'")
-      val = val.substr(1, val.length - 2)
+      val = val.slice(1, -1)
 
     try {
       val = JSON.parse(val)


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.