### PR TITLE
fix: ignore all whitespace lines

### DIFF
--- a/lib/ini.js
+++ b/lib/ini.js
@@ -72,7 +72,7 @@ const decode = str => {
   const lines = str.split(/[\r\n]+/g)
 
   for (const line of lines) {
-    if (!line || line.match(/^\s*[;#]/)) {
+    if (!line || line.match(/^\s*[;#]/) || line.match(/^\s*$/)) {
       continue
     }
     const match = line.match(re)

--- a/test/fixtures/foo.ini
+++ b/test/fixtures/foo.ini
@@ -10,7 +10,7 @@ o = p
 
 ; Test single quotes
 s = 'something'
-
+   
 ; Test mixing quotes
 
 s1 = "something'


### PR DESCRIPTION
A line with only whitespace produces `'':true`
