### PR TITLE
fix: residual space after section causes bad parsing

### DIFF
--- a/lib/ini.js
+++ b/lib/ini.js
@@ -67,8 +67,8 @@ const decode = str => {
   const out = Object.create(null)
   let p = out
   let section = null
-  //          section     |key      = value
-  const re = /^\[([^\]]*)\]$|^([^=]+)(=(.*))?$/i
+  //          section         |key      = value
+  const re = /^\[([^\]]*)\].*$|^([^=]+)(=(.*))?$/i
   const lines = str.split(/[\r\n]+/g)
 
   for (const line of lines) {

--- a/lib/ini.js
+++ b/lib/ini.js
@@ -67,8 +67,8 @@ const decode = str => {
   const out = Object.create(null)
   let p = out
   let section = null
-  //          section         |key      = value
-  const re = /^\[([^\]]*)\].*$|^([^=]+)(=(.*))?$/i
+  //          section          |key      = value
+  const re = /^\[([^\]]*)\]\s*$|^([^=]+)(=(.*))?$/i
   const lines = str.split(/[\r\n]+/g)
 
   for (const line of lines) {

--- a/tap-snapshots/test/foo.js.test.cjs
+++ b/tap-snapshots/test/foo.js.test.cjs
@@ -35,6 +35,7 @@ Null Object {
     "three",
     "this is included",
   ],
+  "b": Null Object {},
   "br": "warm",
   "eq": "eq=eq",
   "false": false,

--- a/test/fixtures/foo.ini
+++ b/test/fixtures/foo.ini
@@ -69,6 +69,9 @@ j = "{ o: "p", a: { av: "a val", b: { c: { e: "this [value]" } } } }"
 cr[] = four
 cr[] = eight
 
+; b section with a space after its title
+[b] 
+
 ; nested child without middle parent
 ; should create otherwise-empty a.b
 [a.b.c]


### PR DESCRIPTION
Any character left on a line after a section should be ignored.
