### PR TITLE
fix: check process on browser

### DIFF
--- a/lib/ini.js
+++ b/lib/ini.js
@@ -172,8 +172,8 @@ const decode = (str, opt = {}) => {
   const remove = []
   for (const k of Object.keys(out)) {
     if (!hasOwnProperty.call(out, k) ||
-      typeof out[k] !== 'object' ||
-      Array.isArray(out[k])) {
+        typeof out[k] !== 'object' ||
+        Array.isArray(out[k])) {
       continue
     }
 

--- a/lib/ini.js
+++ b/lib/ini.js
@@ -8,6 +8,7 @@ const encode = (obj, opt = {}) => {
   opt.newline = opt.newline === true
   opt.sort = opt.sort === true
   opt.whitespace = opt.whitespace === true || opt.align === true
+  // The `typeof` check is required because accessing the `process` directly fails on browsers.
   /* istanbul ignore next */
   opt.platform = opt.platform || (typeof process !== 'undefined' && process.platform)
   opt.bracketedArray = opt.bracketedArray !== false

--- a/lib/ini.js
+++ b/lib/ini.js
@@ -9,7 +9,7 @@ const encode = (obj, opt = {}) => {
   opt.sort = opt.sort === true
   opt.whitespace = opt.whitespace === true || opt.align === true
   /* istanbul ignore next */
-  opt.platform = opt.platform || process?.platform
+  opt.platform = opt.platform || (typeof process === 'undefined' ? null : process.platform)
   opt.bracketedArray = opt.bracketedArray !== false
 
   /* istanbul ignore next */
@@ -172,8 +172,8 @@ const decode = (str, opt = {}) => {
   const remove = []
   for (const k of Object.keys(out)) {
     if (!hasOwnProperty.call(out, k) ||
-        typeof out[k] !== 'object' ||
-        Array.isArray(out[k])) {
+      typeof out[k] !== 'object' ||
+      Array.isArray(out[k])) {
       continue
     }
 

--- a/lib/ini.js
+++ b/lib/ini.js
@@ -9,7 +9,7 @@ const encode = (obj, opt = {}) => {
   opt.sort = opt.sort === true
   opt.whitespace = opt.whitespace === true || opt.align === true
   /* istanbul ignore next */
-  opt.platform = opt.platform || (typeof process === 'undefined' ? null : process.platform)
+  opt.platform = opt.platform || (typeof process !== 'undefined' && process.platform)
   opt.bracketedArray = opt.bracketedArray !== false
 
   /* istanbul ignore next */
@@ -76,7 +76,7 @@ const encode = (obj, opt = {}) => {
   return out
 }
 
-function splitSections (str, separator) {
+function splitSections(str, separator) {
   var lastMatchIndex = 0
   var lastSeparatorIndex = 0
   var nextIndex = 0
@@ -172,8 +172,8 @@ const decode = (str, opt = {}) => {
   const remove = []
   for (const k of Object.keys(out)) {
     if (!hasOwnProperty.call(out, k) ||
-        typeof out[k] !== 'object' ||
-        Array.isArray(out[k])) {
+      typeof out[k] !== 'object' ||
+      Array.isArray(out[k])) {
       continue
     }
 

--- a/lib/ini.js
+++ b/lib/ini.js
@@ -76,7 +76,7 @@ const encode = (obj, opt = {}) => {
   return out
 }
 
-function splitSections(str, separator) {
+function splitSections (str, separator) {
   var lastMatchIndex = 0
   var lastSeparatorIndex = 0
   var nextIndex = 0

--- a/tap-snapshots/test/foo.js.test.cjs
+++ b/tap-snapshots/test/foo.js.test.cjs
@@ -292,3 +292,13 @@ label = debug
 value = 10
 
 `
+
+exports[`test/foo.js TAP encode within browser context > must match snapshot 1`] = `
+[log]
+type=file
+
+[log.level]
+label=debug
+value=10
+
+`

--- a/test/foo.js
+++ b/test/foo.js
@@ -84,3 +84,13 @@ test('encode with align and sort', function (t) {
   t.matchSnapshot(e)
   t.end()
 })
+
+test('encode within browser context', function (t) {
+  process = undefined
+
+  const obj = { log: { type: 'file', level: { label: 'debug', value: 10 } } }
+  const e = i.encode(obj)
+
+  t.matchSnapshot(e)
+  t.end()
+})

--- a/test/foo.js
+++ b/test/foo.js
@@ -86,7 +86,7 @@ test('encode with align and sort', function (t) {
 })
 
 test('encode within browser context', function (t) {
-  process = undefined
+  Object.defineProperty(process, 'platform', { value: undefined })
 
   const obj = { log: { type: 'file', level: { label: 'debug', value: 10 } } }
   const e = i.encode(obj)


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
As mentioned on https://github.com/npm/ini/pull/199#pullrequestreview-1413004935, trying to access `process` in a browser environment fails.

The availability of the value needs to be checked before accessing it.

You can test this easily by running `process?.platform` in the browser console. Instead of resolving to the expected `undefined`, it throws an error.


## References
Relates to https://github.com/npm/ini/pull/199
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
