### PR TITLE
fix: Removed the unused doUnesc param in the unsafe function

### DIFF
--- a/lib/ini.js
+++ b/lib/ini.js
@@ -225,7 +225,7 @@ const safe = val => {
   return val.split(';').join('\\;').split('#').join('\\#')
 }
 
-const unsafe = (val, doUnesc) => {
+const unsafe = val => {
   val = (val || '').trim()
   if (isQuoted(val)) {
     // remove the single quotes before calling JSON.parse


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
The function `unsafe` have a parameter that is not used anywhere : `doUnesc`.
In this PR, this parameter is removed, also making the function declaration syntaxically closer to `safe`.

Before : 
`const unsafe = (val, doUnesc) => {`

Now :
`const unsafe = val => {`

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
N/A