### PR TITLE
fix: decoding bracketed arrays

### DIFF
--- a/lib/ini.js
+++ b/lib/ini.js
@@ -140,7 +140,9 @@ const decode = (str, opt = {}) => {
       duplicates[keyRaw] = (duplicates?.[keyRaw] || 0) + 1
       isArray = duplicates[keyRaw] > 1
     }
-    const key = isArray ? keyRaw.slice(0, -2) : keyRaw
+    const key = isArray && keyRaw.endsWith('[]')
+      ? keyRaw.slice(0, -2) : keyRaw
+
     if (key === '__proto__') {
       continue
     }

--- a/tap-snapshots/test/duplicate-properties.js.test.cjs
+++ b/tap-snapshots/test/duplicate-properties.js.test.cjs
@@ -11,12 +11,12 @@ Null Object {
     "three",
   ],
   "ar[]": "one",
-  "b": Array [
+  "brr": Array [
+    "1",
     "2",
     "3",
     "3",
   ],
-  "brr": "1",
   "str": "3",
   "zr": "123",
   "zr[]": "deedee",


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Previously, the following ini file was being parsed incorrectly:
```ini
brr = 1
brr = 2
brr = 3
brr = 3
```

With `ini.decode(..., {bracketedArray: false})`, this would be parsed as:

```json
{
  "b": [
    "2",
    "3",
    "3"
  ],
  "brr": "1"
}
```

This was due to always running the `key.slice(0, -2)` code.

This PR fixes that so it's now parsed as:

```json
{
  "brr": [
    "1",
    "2",
    "3",
    "3"
  ]
}
```
