### PR TITLE
fix: escape backslashes in values and keys so they round-trip

### DIFF
--- a/lib/ini.js
+++ b/lib/ini.js
@@ -57,7 +57,7 @@ const encode = (obj, opt = {}) => {
   }
 
   if (opt.section && out.length) {
-    out = '[' + safe(opt.section) + ']' + (opt.newline ? eol + eol : eol) + out
+    out = '[' + safe(opt.section, false) + ']' + (opt.newline ? eol + eol : eol) + out
   }
 
   for (const k of children) {
@@ -214,7 +214,7 @@ const isQuoted = val => {
     (val.startsWith("'") && val.endsWith("'"))
 }
 
-const safe = val => {
+const safe = (val, escapeBackslash = true) => {
   if (
     typeof val !== 'string' ||
     val.match(/[=\r\n]/) ||
@@ -224,7 +224,11 @@ const safe = val => {
   ) {
     return JSON.stringify(val)
   }
-  return val.split(';').join('\\;').split('#').join('\\#')
+  // `unsafe` treats `\` as an escape character and unescapes `\\`, `\;` and
+  // `\#`, so values and keys must escape backslashes to round-trip. Section
+  // names opt out because they use `\.` to escape literal dots in key paths.
+  const escaped = escapeBackslash ? val.split('\\').join('\\\\') : val
+  return escaped.split(';').join('\\;').split('#').join('\\#')
 }
 
 const unsafe = val => {

--- a/test/bar.js
+++ b/test/bar.js
@@ -19,3 +19,25 @@ test('parse(stringify(x)) is same as x', function (t) {
 
   t.end()
 })
+
+// `unsafe` unescapes `\\`, `\;` and `\#`, so `safe` has to escape the
+// backslash for those values to survive a round trip.
+test('parse(stringify(x)) round-trips values containing backslashes', function (t) {
+  var values = {
+    'two backslashes': '\\\\', // \ \
+    'windows path': 'C:\\\\tmp\\\\x', // C : \ \ t m p \ \ x
+    'backslash before semicolon': 'a\\;b', // a \ ; b
+    'backslash before hash': 'a\\#b', // a \ # b
+  }
+  for (var label in values) {
+    var obj = { k: values[label] }
+    t.same(ini.parse(ini.stringify(obj)), obj, label)
+  }
+
+  // a backslash in a key name has to round-trip as well
+  var keyed = {}
+  keyed['a\\\\b'] = 'v' // a \ \ b
+  t.same(ini.parse(ini.stringify(keyed)), keyed, 'backslash in key')
+
+  t.end()
+})


### PR DESCRIPTION
`ini.parse(ini.stringify(x))` is not stable when a value or key contains a backslash.

`unsafe` treats `\` as an escape character: in the unquoted branch it unescapes `\\`, `\;` and `\#`. `safe` only escaped `;` and `#`, never the backslash itself, so a backslash that is written verbatim is read back as an escape sequence. Two backslashes collapse to one, and a backslash placed before `;` or `#` gets swallowed.

```js
const ini = require('ini')

// a value of two backslashes comes back as one
ini.parse(ini.stringify({ k: '\\\\' }))      // { k: '\\' }
ini.parse(ini.stringify({ p: 'C:\\\\tmp' })) // { p: 'C:\\tmp' }
```

This makes `safe` escape the backslash as well, so it is the inverse of `unsafe`. Section names are left unchanged: they use `\.` to escape literal dots in key paths, so `safe` is called with `escapeBackslash = false` for the section to avoid doubling those structural backslashes. The existing snapshots are byte-identical.

Round-trip tests are added in `test/bar.js` (two backslashes, a Windows-style path, `\;`/`\#`, and a backslash in a key). `npm test` passes at 100% coverage, and reverting the one-line change makes the new cases fail.

This is the behaviour #9 had in mind: "a `\\` needs to be a `\` and not an escape".
