### PR TITLE
fix: parse comments following quoted values

### DIFF
--- a/lib/ini.js
+++ b/lib/ini.js
@@ -229,6 +229,31 @@ const safe = val => {
 
 const unsafe = val => {
   val = (val || '').trim()
+  if (val.charAt(0) === '"' || val.charAt(0) === "'") {
+    let quote = null
+    let escaped = false
+    let commentIndex = -1
+    for (let i = 0; i < val.length; i++) {
+      const c = val.charAt(i)
+      if (escaped) {
+        escaped = false
+      } else if (c === '\\') {
+        escaped = true
+      } else if (quote) {
+        if (c === quote) {
+          quote = null
+        }
+      } else if (c === '"' || c === "'") {
+        quote = c
+      } else if (c === ';' || c === '#') {
+        commentIndex = i
+        break
+      }
+    }
+    if (commentIndex !== -1) {
+      val = val.slice(0, commentIndex).trim()
+    }
+  }
   if (isQuoted(val)) {
     // remove the single quotes before calling JSON.parse
     if (val.charAt(0) === "'") {

--- a/test/foo.js
+++ b/test/foo.js
@@ -14,6 +14,12 @@ test('decode from file', function (t) {
   t.end()
 })
 
+test('decode quoted values before inline comments', function (t) {
+  const d = i.decode('double = "value" ; comment\nsingle = \'value\' # comment\n')
+  t.same(d, { double: 'value', single: 'value' })
+  t.end()
+})
+
 test('encode from data', function (t) {
   const d = i.decode(data)
   const e = i.encode(d)


### PR DESCRIPTION
Fixes #89.

Recognize inline comments that follow a closed quoted value without treating the comment as part of the value. Adds regression coverage for both comment delimiters.

Tests: full suite with 100% statement/branch/function/line coverage and ESLint.